### PR TITLE
in branch branch tracking

### DIFF
--- a/packages/github-mirror/src/Mirror.ts
+++ b/packages/github-mirror/src/Mirror.ts
@@ -53,7 +53,7 @@ export class Mirror {
             gitSync(gitDir, context, 'remote', 'add', 'github', githubUrl);
             gitSync(gitDir, context, 'fetch', 'github', remoteBranchName);
             gitSync(gitDir, context, 'reset', '--hard', remoteCommitId !== undefined ? remoteCommitId : `github/${remoteBranchName}`);
-            gitSync(gitDir, context, 'push', 'aws', `HEAD:${localBranchName}`);
+            gitSync(gitDir, context, 'push', 'aws', `HEAD:${localBranchName}`, '--force');
         }
         else {
             gitSync(gitDir, context, 'push', 'aws', `:${localBranchName}`);

--- a/packages/sns-to-slack/src/index.ts
+++ b/packages/sns-to-slack/src/index.ts
@@ -13,14 +13,20 @@ interface StatusSetting {
     emoji?: string;
 }
 
+interface EnvVar {
+    name?: string;
+    value?: string;
+}
+
 interface Payload {
     buildStatus: Status;
     projectName: string;
     repositoryName: string;
-    branchName: string;
+    branchName?: string;
     buildId: string;
     region: string;
     icon: string;
+    buildEnvironment?: Array<EnvVar>;
     slackSettings: Array<{
         uri: string;
         channel: string;
@@ -61,8 +67,10 @@ export const handler = async (event: SNSEvent): Promise<void> => {
                 },
             };
 
+            const branchName = payload.branchName ?? payload.buildEnvironment?.find((envVar) => envVar.name === 'SOURCE_BRANCH_NAME')?.value;
+
             const prefix = 'https://' + payload.region + '.console.aws.amazon.com/codesuite/';
-            const codeCommitLink = prefix + 'codecommit/repositories/' + payload.repositoryName + '/browse/refs/heads/' + payload.branchName + '?region=' + payload.region;
+            const codeCommitLink = prefix + 'codecommit/repositories/' + payload.repositoryName + '/browse/refs/heads/' + branchName + '?region=' + payload.region;
             const codeBuildLink = prefix + 'codebuild/projects/' + payload.projectName + '/build/' + payload.buildId.split('/').pop() + '/log?region=' + payload.region;
 
             const normalizedStatus = toWords(payload.buildStatus);

--- a/packages/synthesizer/src/orchestrator/CloudWatchOrchestratorFactory.ts
+++ b/packages/synthesizer/src/orchestrator/CloudWatchOrchestratorFactory.ts
@@ -52,7 +52,13 @@ class CloudWatchOrchestratorStage implements Stage {
             target: new targets.CodeBuildProject(props.project, {
                 event: RuleTargetInput.fromObject({
                     sourceVersion: EventField.fromPath('$.detail.commitId'),
-                    sourceIdentifier: EventField.fromPath('$.detail.referenceName'),
+                    environmentVariablesOverride: [
+                        {
+                            name: 'SOURCE_BRANCH_NAME',
+                            value: EventField.fromPath('$.detail.referenceName'),
+                            type: 'PLAINTEXT',
+                        }
+                    ],
                 })
             }),
             eventPattern: {


### PR DESCRIPTION
- pass branch name into code commit events for codebuild, buildEnvironment into codebuild events and read it out in sns to slack so we can detect the branch of an in-branch build.
- force push in github mirror