### PR TITLE
do not pre-build things.

### DIFF
--- a/packages/synthesizer/src/index.ts
+++ b/packages/synthesizer/src/index.ts
@@ -18,33 +18,33 @@ import {Secret} from './fn/resolvers/Secret';
 import {Tokenizer} from '@ddcp/tokenizer';
 import {CounterResourceFactory} from './resource/CounterResourceFactory';
 
-const uniquifier = new Uniquifier();
-const tokenizer = new Tokenizer();
-
-const resolvers: Record<string, BaseFn<unknown, Array<unknown>>> = {};
-const resourceFactories: Record<string, BaseResourceFactory> = {};
-const orchestratorFactories: Record<string, BaseOrchestratorFactory> = {};
-
-new Join(resolvers).init();
-new Path(resolvers, resourceFactories).init();
-new PathForAlias(resolvers).init();
-new Import(resolvers).init();
-new SsmString(resolvers, uniquifier).init();
-new Secret(resolvers, tokenizer).init();
-
-const resolver = new Resolver(resolvers);
-
-new CodePipelineOrchestratorFactory(orchestratorFactories).init();
-new CloudWatchOrchestratorFactory(orchestratorFactories).init();
-
-new CounterResourceFactory(resourceFactories, tokenizer, uniquifier).init();
-
 const isCodePipelineEvent = (event: unknown): event is CodePipelineEvent => {
     return typeof event === 'object' && event !== null && (event as Record<string, undefined>)['CodePipeline.job'] !== undefined;
 };
 
 export const handler = async (event: CodePipelineEvent | CodeCommitEvent, context: Context): Promise<void> => {
     if (isCodePipelineEvent(event)) {
+        const uniquifier = new Uniquifier();
+        const tokenizer = new Tokenizer();
+
+        const resolvers: Record<string, BaseFn<unknown, Array<unknown>>> = {};
+        const resourceFactories: Record<string, BaseResourceFactory> = {};
+        const orchestratorFactories: Record<string, BaseOrchestratorFactory> = {};
+
+        new Join(resolvers).init();
+        new Path(resolvers, resourceFactories).init();
+        new PathForAlias(resolvers).init();
+        new Import(resolvers).init();
+        new SsmString(resolvers, uniquifier).init();
+        new Secret(resolvers, tokenizer).init();
+
+        const resolver = new Resolver(resolvers);
+
+        new CodePipelineOrchestratorFactory(orchestratorFactories).init();
+        new CloudWatchOrchestratorFactory(orchestratorFactories).init();
+
+        new CounterResourceFactory(resourceFactories, tokenizer, uniquifier).init();
+
         return new SynthesisHandler().safeHandle({
             event,
             context,


### PR DESCRIPTION
Anything not caching cdk constructs can be pre-built, but for now it is
easier to just not have any global state.