### PR TITLE
feat: cachecontrol no-cache

### DIFF
--- a/packages/codepipeline-badge/src/Handler.ts
+++ b/packages/codepipeline-badge/src/Handler.ts
@@ -64,7 +64,7 @@ export class Handler {
             Bucket: event.assetsBucket,
             Key: event.assetsKey,
             Body: asset,
-            CacheControl: 'max-age=10',
+            CacheControl: 'no-cache',
             ContentType: 'image/svg+xml',
             ACL: 'public-read',
         }).promise();


### PR DESCRIPTION
This is to speed up GitHub updating as it caches behind its own CDN.